### PR TITLE
Feat: display error message

### DIFF
--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -13,6 +13,6 @@ export async function POST(req: Request) {
 		return NextResponse.json(response.data);
 	} catch (error) {
 		console.log({ error });
-		return NextResponse.json(error);
+		return error;
 	}
 }

--- a/src/components/ErrorMessage.tsx
+++ b/src/components/ErrorMessage.tsx
@@ -1,0 +1,17 @@
+const ErrorMessage = ({ content }: { content: string }) => {
+	return (
+		<div
+			style={{
+				width: '100%',
+				backgroundColor: '#f4e6e6',
+				border: '1px solid #cf999a',
+				borderRadius: '8px',
+				padding: '12px'
+			}}
+		>
+			<p>{content}</p>
+		</div>
+	);
+};
+
+export default ErrorMessage;

--- a/src/components/MessagesList.tsx
+++ b/src/components/MessagesList.tsx
@@ -7,6 +7,7 @@ import ComponentMessage from '@/components/ComponentMessage';
 import Avatar from '@/components/Avatar';
 import AssistantMessage from '@/components/AssistantMessage';
 import { CodeBlock } from './CodeBlock';
+import ErrorMessage from './ErrorMessage';
 // utils
 import { cn } from '@/utils/utils';
 import { Message } from 'ai';
@@ -45,7 +46,9 @@ const MessagesList = ({ messages }: { messages: Message[] }) => {
 								</div>
 
 								{/* ASSISTANT MESSAGE */}
-								{item.role === 'assistant' ? (
+								{item.id?.includes('error') ? (
+									<ErrorMessage content={parseItemOutput?.message?.content ?? ''} />
+								) : item.role === 'assistant' ? (
 									/* ASSISTANT MESSAGE */
 
 									<div

--- a/src/hooks/useChatCustom/useChatCustom.tsx
+++ b/src/hooks/useChatCustom/useChatCustom.tsx
@@ -55,6 +55,11 @@ const useChatCustom = () => {
 			});
 		} catch (error) {
 			console.error(error);
+			setNewMessage({
+				content: 'An error ocurred. Try again later',
+				id: `error-${nanoid()}`,
+				role: 'assistant'
+			});
 		}
 	}, []);
 


### PR DESCRIPTION
<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

Error messages are not display.

## What is the new behavior?

Error message from openai in chat

![CHATAI-UNGGA--error-message](https://github.com/Nuclea-Solutions/chatgpt-dynamic-ui/assets/82394561/9155a213-f3db-4cb7-a7d3-ab87488914ac)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
